### PR TITLE
Remove error & unused code tokens

### DIFF
--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -235,25 +235,10 @@ struct Content_View_Previews: PreviewProvider {
 			ForEach(0 ..< 4) { item in
 				DigiTextView(placeholder: "Placeholder", text: .constant(""), presentingModal: false, alignment: .leading)
 			}
-			Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-				/*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
-			}
 		}
 	}
 }
 
-struct TextField_Previews: PreviewProvider {
-	static var previews: some View{
-		ScrollView{
-			ForEach(0 ..< 4){ item in
-				TextField(/*@START_MENU_TOKEN@*/"Placeholder"/*@END_MENU_TOKEN@*/, text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
-			}
-			Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-				/*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
-			}
-		}
-	}
-}
 #endif
 #endif
 #if os(watchOS)

--- a/Sources/SwiftUI Apple Watch Decimal Pad/Modifiers.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/Modifiers.swift
@@ -69,8 +69,6 @@ public struct DigitPadStyle: ButtonStyle {
         
 	}
 }
-#else
-#error("This is a watchOS only library.")
 #endif
 public enum TextViewAlignment {
 	case trailing


### PR DESCRIPTION
Removing the error should mitigate compilation problems in projects that include iOS and watchOS.

The other deletions are to remove tokens supplied by default code that do not work in their current state.