### PR TITLE
Fix issue where this package was interfering with SwiftUI previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftUI Apple Watch Decimal Pad",
-    platforms: [.watchOS(.v7)],
+    platforms: [.watchOS(.v7),
+                .macOS(.v11),
+                .iOS(.v14),
+                .tvOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -92,8 +92,10 @@ public struct EnteredText: View {
 		}
         .toolbar(content: {
             ToolbarItem(placement: .cancellationAction){
-                Button("Done"){
+                Button {
                     presentedAsModal.toggle()
+                } label: {
+                    Label("Done", systemImage: "xmark")
                 }
             }
         })

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -298,6 +298,4 @@ struct TextField_Previews: PreviewProvider {
 		}
 	}
 }
-#else
-#error("This is a watchOS only library.")
 #endif

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 #if os(watchOS)
 @available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 public struct DigiTextView: View {
     private var locale: Locale
     var style: KeyboardStyle
@@ -44,6 +48,10 @@ public struct DigiTextView: View {
 	}
 }
 @available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 public struct EnteredText: View {
 	@Binding var text:String
 	@Binding var presentedAsModal: Bool
@@ -92,7 +100,11 @@ public struct EnteredText: View {
         
 	}
 }
-@available(iOS 13.0, watchOS 6.0, *)
+@available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
  public struct DigetPadView: View {
 	public var widthSpace: CGFloat = 1.0
 	@Binding var text:String
@@ -204,10 +216,42 @@ public struct EnteredText: View {
         .font(.title2)
 	}
 }
+
+@available(iOS 13.0, watchOS 6.0, *)
+struct TextViewStyle: ButtonStyle {
+    init(alignment: TextViewAlignment = .center) {
+        self.align = alignment
+    }
+    
+    
+    var align: TextViewAlignment
+    func makeBody(configuration: Configuration) -> some View {
+            HStack {
+                if align == .center || align == .trailing{
+                Spacer()
+                }
+                configuration.label
+                    .font(/*@START_MENU_TOKEN@*/.body/*@END_MENU_TOKEN@*/)
+                    .padding(.vertical, 11.0)
+                    .padding(.horizontal)
+                if align == .center || align == .leading{
+                Spacer()
+                }
+            }
+            .background(
+                GeometryReader { geometry in
+                    ZStack{
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(configuration.isPressed ? Color.gray.opacity(0.1): Color.gray.opacity(0.2))
+                    }
+            })
+            
+    }
+    
+}
 #endif
 
-#if DEBUG
-#if os(watchOS)
+#if DEBUG && os(watchOS)
 struct EnteredText_Previews: PreviewProvider {
 	static var previews: some View {
         EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers)
@@ -254,39 +298,6 @@ struct TextField_Previews: PreviewProvider {
 		}
 	}
 }
-#endif
-#endif
-#if os(watchOS)
-@available(iOS 13.0, watchOS 6.0, *)
-struct TextViewStyle: ButtonStyle {
-    init(alignment: TextViewAlignment = .center) {
-		self.align = alignment
-	}
-	
-	
-	var align: TextViewAlignment
-	func makeBody(configuration: Configuration) -> some View {
-			HStack {
-				if align == .center || align == .trailing{
-				Spacer()
-				}
-				configuration.label
-					.font(/*@START_MENU_TOKEN@*/.body/*@END_MENU_TOKEN@*/)
-					.padding(.vertical, 11.0)
-					.padding(.horizontal)
-				if align == .center || align == .leading{
-				Spacer()
-				}
-			}
-			.background(
-				GeometryReader { geometry in
-					ZStack{
-				RoundedRectangle(cornerRadius: 7, style: .continuous)
-					.fill(configuration.isPressed ? Color.gray.opacity(0.1): Color.gray.opacity(0.2))
-					}
-			})
-			
-	}
-	
-}
+#else
+#error("This is a watchOS only library.")
 #endif

--- a/Sources/SwiftUI Apple Watch Decimal Pad/Modifiers.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/Modifiers.swift
@@ -7,9 +7,12 @@
 
 import Foundation
 import SwiftUI
-#if os(watchOS)
-import WatchKit
+
 @available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 public struct DigitButtonModifier: ViewModifier {
 	public func body(content: Content) -> some View {
 		return content
@@ -18,14 +21,22 @@ public struct DigitButtonModifier: ViewModifier {
 	}
 }
 
-
 @available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 public extension Button {
 	func digitKeyFrame() -> some View {
 		self.modifier(DigitButtonModifier())
 	}
 }
+
 @available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
 public struct DigitPadStyle: ButtonStyle {
 	public func makeBody(configuration: Configuration) -> some View {
         GeometryReader(content: { geometry in
@@ -69,9 +80,7 @@ public struct DigitPadStyle: ButtonStyle {
         
 	}
 }
-#else
-#error("This is a watchOS only library.")
-#endif
+
 public enum TextViewAlignment {
 	case trailing
 	case leading
@@ -82,8 +91,8 @@ public enum KeyboardStyle {
     case decimal
     case numbers
 }
-#if DEBUG
-#if os(watchOS)
+
+#if DEBUG && os(watchOS)
 struct EnteredTextKeys_Previews: PreviewProvider {
     static var previews: some View {
         EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers)
@@ -97,5 +106,6 @@ struct EnteredTextKeys_Previews: PreviewProvider {
         EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 3 - 42mm")
     }
 }
-#endif
+#else
+#error("This is a watchOS only library.")
 #endif

--- a/Sources/SwiftUI Apple Watch Decimal Pad/Modifiers.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/Modifiers.swift
@@ -106,6 +106,4 @@ struct EnteredTextKeys_Previews: PreviewProvider {
         EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 3 - 42mm")
     }
 }
-#else
-#error("This is a watchOS only library.")
 #endif


### PR DESCRIPTION
In the previous release, the #error statement kept on tripping the SwiftUI previews for other OSes into thinking that it needs to compile the digit pad in this package. This PR should try to mitigate this issue by using the @available(platform, unavailable) pattern on the top of a struct, as well as adding the other OSes onto the Package.swift (as seen in #5). I think this is technically an Xcode issue, but that bug has been here for a while to the point that this might be the best we can do at the moment.