### PR TITLE
Adding a stepper for watchOS 9+ so that users can use crown or tap to increment by low numbers

### DIFF
--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -61,12 +61,11 @@ public struct DigiNumberView: View {
     @State public var presentingModal: Bool
     
     var align: TextViewAlignment
-    public init(placeholder: String, number: Binding<Int>, presentingModal:Bool, alignment: TextViewAlignment = .center,style: KeyboardStyle = .numbers, locale: Locale = .current){
+    public init(placeholder: String, number: Binding<Int>, presentingModal:Bool, alignment: TextViewAlignment = .center, locale: Locale = .current){
         _number = number
         _presentingModal = State(initialValue: presentingModal)
         self.align = alignment
         self.placeholder = placeholder
-        self.style = style
         self.locale = locale
     }
     
@@ -85,7 +84,7 @@ public struct DigiNumberView: View {
             Text(number.description)
         }.buttonStyle(TextViewStyle(alignment: align))
             .sheet(isPresented: $presentingModal, content: {
-                EnteredText(text: text, presentedAsModal: $presentingModal, style: self.style, locale: locale)
+                EnteredText(text: text, presentedAsModal: $presentingModal, style: .numbers, locale: locale)
             })
     }
 }

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -15,37 +15,37 @@ import SwiftUI
 public struct DigiTextView: View {
     private var locale: Locale
     var style: KeyboardStyle
-	var placeholder: String
-	@Binding public var text: String
-	@State public var presentingModal: Bool
-	
-	var align: TextViewAlignment
+    var placeholder: String
+    @Binding public var text: String
+    @State public var presentingModal: Bool
+    
+    var align: TextViewAlignment
     public init( placeholder: String, text: Binding<String>, presentingModal:Bool, alignment: TextViewAlignment = .center,style: KeyboardStyle = .numbers, locale: Locale = .current){
-		_text = text
-		_presentingModal = State(initialValue: presentingModal)
-		self.align = alignment
-		self.placeholder = placeholder
+        _text = text
+        _presentingModal = State(initialValue: presentingModal)
+        self.align = alignment
+        self.placeholder = placeholder
         self.style = style
         self.locale = locale
-	}
-	
-	public var body: some View {
-		Button(action: {
-			presentingModal.toggle()
-		}) {
-			if text != ""{
+    }
+    
+    public var body: some View {
+        Button(action: {
+            presentingModal.toggle()
+        }) {
+            if text != ""{
                 Text(text)
-			}
-			else{
-				Text(placeholder)
-					.lineLimit(1)
-					.opacity(0.5)
-			}
-		}.buttonStyle(TextViewStyle(alignment: align))
-		.sheet(isPresented: $presentingModal, content: {
-            EnteredText(text: $text, presentedAsModal: $presentingModal, style: self.style, locale: locale)
-		})		
-	}
+            }
+            else{
+                Text(placeholder)
+                    .lineLimit(1)
+                    .opacity(0.5)
+            }
+        }.buttonStyle(TextViewStyle(alignment: align))
+            .sheet(isPresented: $presentingModal, content: {
+                EnteredText(text: $text, presentedAsModal: $presentingModal, style: self.style, locale: locale)
+            })
+    }
 }
 @available(watchOS 6.0, *)
 @available(macOS, unavailable)
@@ -53,23 +53,42 @@ public struct DigiTextView: View {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 public struct EnteredText: View {
-	@Binding var text:String
-	@Binding var presentedAsModal: Bool
+    @Binding var text: String
+    @Binding var presentedAsModal: Bool
     var style: KeyboardStyle
     var watchOSDimensions: CGRect?
     private var locale: Locale
     
-	public init(text: Binding<String>, presentedAsModal:
-                Binding<Bool>, style: KeyboardStyle, locale: Locale = .current){
-		_text = text
-		_presentedAsModal = presentedAsModal
+    public init(text: Binding<String>, presentedAsModal:
+                Binding<Bool>, style: KeyboardStyle, locale: Locale = .current) {
+        _text = text
+        _presentedAsModal = presentedAsModal
         self.style = style
         self.locale = locale
         let device = WKInterfaceDevice.current()
         watchOSDimensions = device.screenBounds
-	}
-	public var body: some View{
-		VStack(alignment: .trailing) {
+    }
+    
+    var number: Binding<Int> {
+        Binding {
+            Int(text) ?? 0
+        } set: { new in
+            text = String(new)
+        }
+    }
+    
+    public var body: some View{
+        VStack(alignment: .trailing) {
+            if #available(watchOS 26, *) {
+                Stepper(value: number, in: 0...Int.max) {
+                    HStack {
+                        Spacer()
+                        Text(number.wrappedValue.description)
+                            .font(.body)
+                    }
+                    .padding(.horizontal)
+                }
+            } else {
                 Button(action:{
                     presentedAsModal.toggle()
                 }){
@@ -79,6 +98,7 @@ public struct EnteredText: View {
                             .foregroundColor(.clear
                             )
                     })
+                    
                     Text(text)
                         .font(.title2)
                         .frame(height: watchOSDimensions!.height * 0.15, alignment: .trailing)
@@ -86,10 +106,11 @@ public struct EnteredText: View {
                 .buttonStyle(PlainButtonStyle())
                 .multilineTextAlignment(.trailing)
                 .lineLimit(1)
-                
-                DigetPadView(text: $text, style: style, locale: locale)
-                    .edgesIgnoringSafeArea(/*@START_MENU_TOKEN@*/.all/*@END_MENU_TOKEN@*/)
-		}
+            }
+            
+            DigetPadView(text: $text, style: style, locale: locale)
+                .edgesIgnoringSafeArea(/*@START_MENU_TOKEN@*/.all/*@END_MENU_TOKEN@*/)
+        }
         .toolbar(content: {
             ToolbarItem(placement: .cancellationAction){
                 Button {
@@ -100,87 +121,93 @@ public struct EnteredText: View {
             }
         })
         
-	}
+    }
 }
 @available(watchOS 6.0, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
- public struct DigetPadView: View {
-	public var widthSpace: CGFloat = 1.0
-	@Binding var text:String
+public struct DigetPadView: View {
+    public var widthSpace: CGFloat = 1.0
+    @Binding var text:String
     var style: KeyboardStyle
     private var decimalSeparator: String
     public init(text: Binding<String>, style: KeyboardStyle, locale: Locale = .current) {
-		_text = text
+        _text = text
         self.style = style
-
+        
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = locale
         decimalSeparator = numberFormatter.decimalSeparator
-	}
-	 public var body: some View {
+    }
+    public var body: some View {
         VStack(spacing: 1) {
-			HStack(spacing: widthSpace){
-				Button(action: {
-					text.append("1")
-				}) {
-					Text("1")
-						.padding(0)
-				}
-				.digitKeyFrame()
-				Button(action: {
-					text.append("2")
-				}) {
-					Text("2")
-				}.digitKeyFrame()
-				
-				Button(action: {
-					text.append("3")
-				}) {
-							Text("3")
-						}.digitKeyFrame()
-			}
-			HStack(spacing:widthSpace){
-				Button(action: {
-					text.append("4")
-				}) {
-					Text("4")
-				}.digitKeyFrame()
-				Button(action: {
-					text.append("5")
-				}) {
-					Text("5")
-				}.digitKeyFrame()
-				
-				Button(action: {
-					text.append("6")
-				}) {
-					Text("6")
-				}.digitKeyFrame()
-			}
-			
-			HStack(spacing:widthSpace){
-				Button(action: {
-					text.append("7")
-				}) {
-					Text("7")
-				}.digitKeyFrame()
-				Button(action: {
-					text.append("8")
-				}) {
-					Text("8")
-				}.digitKeyFrame()
-				
-				Button(action: {
-					text.append("9")
-				}) {
-					Text("9")
-				}
-				.digitKeyFrame()
-			}
-			HStack(spacing:widthSpace) {
+            HStack(spacing: widthSpace){
+                Button(action: {
+                    text.append("1")
+                }) {
+                    Text("1")
+                        .padding(0)
+                }
+                .digitKeyFrame()
+                Button(action: {
+                    text.append("2")
+                }) {
+                    Text("2")
+                }
+                .digitKeyFrame()
+                
+                Button(action: {
+                    text.append("3")
+                }) {
+                    Text("3")
+                }
+                .digitKeyFrame()
+            }
+            HStack(spacing:widthSpace){
+                Button(action: {
+                    text.append("4")
+                }) {
+                    Text("4")
+                }.digitKeyFrame()
+                Button(action: {
+                    text.append("5")
+                }) {
+                    Text("5")
+                }
+                .digitKeyFrame()
+                
+                Button(action: {
+                    text.append("6")
+                }) {
+                    Text("6")
+                }
+                .digitKeyFrame()
+            }
+            
+            HStack(spacing:widthSpace){
+                Button(action: {
+                    text.append("7")
+                }) {
+                    Text("7")
+                }
+                .digitKeyFrame()
+                Button(action: {
+                    text.append("8")
+                }) {
+                    Text("8")
+                }
+                .digitKeyFrame()
+                
+                Button(action: {
+                    text.append("9")
+                }) {
+                    Text("9")
+                }
+                .digitKeyFrame()
+            }
+            HStack(spacing:widthSpace) {
                 if style == .decimal {
                     Button(action: {
                         if !(text.contains(decimalSeparator)){
@@ -198,25 +225,25 @@ public struct EnteredText: View {
                     Spacer()
                         .padding(1)
                 }
-				Button(action: {
-					text.append("0")
-				}) {
-					Text("0")
-				}
-				.digitKeyFrame()
-				
-				Button(action: {
-					if let last = text.indices.last{
-						text.remove(at: last)
-					}
-				}) {
-					Image(systemName: "delete.left")
-				}
-				.digitKeyFrame()
-			}
+                Button(action: {
+                    text.append("0")
+                }) {
+                    Text("0")
+                }
+                .digitKeyFrame()
+                
+                Button(action: {
+                    if let last = text.indices.last{
+                        text.remove(at: last)
+                    }
+                }) {
+                    Image(systemName: "delete.left")
+                }
+                .digitKeyFrame()
+            }
         }
         .font(.title2)
-	}
+    }
 }
 
 @available(iOS 13.0, watchOS 6.0, *)
@@ -228,76 +255,82 @@ struct TextViewStyle: ButtonStyle {
     
     var align: TextViewAlignment
     func makeBody(configuration: Configuration) -> some View {
-            HStack {
-                if align == .center || align == .trailing{
+        HStack {
+            if align == .center || align == .trailing{
                 Spacer()
-                }
-                configuration.label
-                    .font(/*@START_MENU_TOKEN@*/.body/*@END_MENU_TOKEN@*/)
-                    .padding(.vertical, 11.0)
-                    .padding(.horizontal)
-                if align == .center || align == .leading{
-                Spacer()
-                }
             }
-            .background(
-                GeometryReader { geometry in
-                    ZStack{
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .fill(configuration.isPressed ? Color.gray.opacity(0.1): Color.gray.opacity(0.2))
-                    }
+            configuration.label
+                .font(/*@START_MENU_TOKEN@*/.body/*@END_MENU_TOKEN@*/)
+                .padding(.vertical, 11.0)
+                .padding(.horizontal)
+            if align == .center || align == .leading{
+                Spacer()
+            }
+        }
+        .background(
+            GeometryReader { geometry in
+                ZStack{
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(configuration.isPressed ? Color.gray.opacity(0.1): Color.gray.opacity(0.2))
+                }
             })
-            
+        
     }
     
 }
 #endif
 
-#if DEBUG && os(watchOS)
-struct EnteredText_Previews: PreviewProvider {
-	static var previews: some View {
-        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers)
-        Group {
-            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
-            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
-                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
-            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
-                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
-                .accessibilityElement(children: /*@START_MENU_TOKEN@*/.contain/*@END_MENU_TOKEN@*/)
-                
-        }
-        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 6 - 40mm")
-        Group {
-            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers).previewDevice("Apple Watch Series 3 - 38mm")
-            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers).environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge).previewDevice("Apple Watch Series 3 - 38mm")
-        }
-        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 3 - 42mm")
-	}
-}
+//#if DEBUG && os(watchOS)
+//struct EnteredText_Previews: PreviewProvider {
+//    static var previews: some View {
+//        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers)
+//        Group {
+//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
+//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
+//                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
+//                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+//                .accessibilityElement(children: /*@START_MENU_TOKEN@*/.contain/*@END_MENU_TOKEN@*/)
+//            
+//        }
+//        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 6 - 40mm")
+//        Group {
+//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers).previewDevice("Apple Watch Series 3 - 38mm")
+//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers).environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge).previewDevice("Apple Watch Series 3 - 38mm")
+//        }
+//        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 3 - 42mm")
+//    }
+//}
+//
+//struct Content_View_Previews: PreviewProvider {
+//    static var previews: some View{
+//        ScrollView {
+//            ForEach(0 ..< 4) { item in
+//                DigiTextView(placeholder: "Placeholder", text: .constant(""), presentingModal: false, alignment: .leading)
+//            }
+//            Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
+//                /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
+//            }
+//        }
+//    }
+//}
+//
+//struct TextField_Previews: PreviewProvider {
+//    static var previews: some View{
+//        ScrollView{
+//            ForEach(0 ..< 4){ item in
+//                TextField(/*@START_MENU_TOKEN@*/"Placeholder"/*@END_MENU_TOKEN@*/, text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
+//            }
+//            Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
+//                /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
+//            }
+//        }
+//    }
+//}
+//#endif
 
-struct Content_View_Previews: PreviewProvider {
-	static var previews: some View{
-		ScrollView {
-			ForEach(0 ..< 4) { item in
-				DigiTextView(placeholder: "Placeholder", text: .constant(""), presentingModal: false, alignment: .leading)
-			}
-			Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-				/*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
-			}
-		}
-	}
+@available(watchOS 10, *)
+#Preview {
+    @Previewable @State var text: String = "0"
+    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
 }
-
-struct TextField_Previews: PreviewProvider {
-	static var previews: some View{
-		ScrollView{
-			ForEach(0 ..< 4){ item in
-				TextField(/*@START_MENU_TOKEN@*/"Placeholder"/*@END_MENU_TOKEN@*/, text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
-			}
-			Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-				/*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
-			}
-		}
-	}
-}
-#endif

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -18,9 +18,13 @@ public struct DigiTextView: View {
     var placeholder: String
     @Binding public var text: String
     @State public var presentingModal: Bool
-    
+
     var align: TextViewAlignment
-    public init(placeholder: String, text: Binding<String>, presentingModal:Bool, alignment: TextViewAlignment = .center,style: KeyboardStyle = .numbers, locale: Locale = .current){
+    public init(
+        placeholder: String, text: Binding<String>, presentingModal: Bool,
+        alignment: TextViewAlignment = .center, style: KeyboardStyle = .numbers,
+        locale: Locale = .current
+    ) {
         _text = text
         _presentingModal = State(initialValue: presentingModal)
         self.align = alignment
@@ -28,23 +32,26 @@ public struct DigiTextView: View {
         self.style = style
         self.locale = locale
     }
-    
+
     public var body: some View {
         Button(action: {
             presentingModal.toggle()
         }) {
-            if text != ""{
+            if text != "" {
                 Text(text)
-            }
-            else{
+            } else {
                 Text(placeholder)
                     .lineLimit(1)
                     .opacity(0.5)
             }
         }.buttonStyle(TextViewStyle(alignment: align))
-            .sheet(isPresented: $presentingModal, content: {
-                EnteredText(text: $text, presentedAsModal: $presentingModal, style: self.style, locale: locale)
-            })
+            .sheet(
+                isPresented: $presentingModal,
+                content: {
+                    EnteredText(
+                        text: $text, presentedAsModal: $presentingModal, style: self.style,
+                        locale: locale)
+                })
     }
 }
 
@@ -58,16 +65,19 @@ public struct DigiNumberView: View {
     var placeholder: String
     @Binding public var number: Int
     @State public var presentingModal: Bool
-    
+
     var align: TextViewAlignment
-    public init(placeholder: String, number: Binding<Int>, presentingModal:Bool, alignment: TextViewAlignment = .center, locale: Locale = .current){
+    public init(
+        placeholder: String, number: Binding<Int>, presentingModal: Bool,
+        alignment: TextViewAlignment = .center, locale: Locale = .current
+    ) {
         _number = number
         _presentingModal = State(initialValue: presentingModal)
         self.align = alignment
         self.placeholder = placeholder
         self.locale = locale
     }
-    
+
     var text: Binding<String> {
         Binding {
             number.description
@@ -75,16 +85,20 @@ public struct DigiNumberView: View {
             number = Int(newValue) ?? 0
         }
     }
-    
+
     public var body: some View {
         Button(action: {
             presentingModal.toggle()
         }) {
             Text(number.description)
         }.buttonStyle(TextViewStyle(alignment: align))
-            .sheet(isPresented: $presentingModal, content: {
-                EnteredText(text: text, presentedAsModal: $presentingModal, style: .numbers, locale: locale)
-            })
+            .sheet(
+                isPresented: $presentingModal,
+                content: {
+                    EnteredText(
+                        text: text, presentedAsModal: $presentingModal, style: .numbers,
+                        locale: locale)
+                })
     }
 }
 
@@ -99,9 +113,12 @@ public struct EnteredText: View {
     var style: KeyboardStyle
     var watchOSDimensions: CGRect?
     private var locale: Locale
-    
-    public init(text: Binding<String>, presentedAsModal:
-                Binding<Bool>, style: KeyboardStyle, locale: Locale = .current) {
+
+    public init(
+        text: Binding<String>,
+        presentedAsModal:
+            Binding<Bool>, style: KeyboardStyle, locale: Locale = .current
+    ) {
         _text = text
         _presentedAsModal = presentedAsModal
         self.style = style
@@ -109,7 +126,7 @@ public struct EnteredText: View {
         let device = WKInterfaceDevice.current()
         watchOSDimensions = device.screenBounds
     }
-    
+
     var number: Binding<Int> {
         Binding {
             Int(text) ?? 0
@@ -117,8 +134,8 @@ public struct EnteredText: View {
             text = String(new)
         }
     }
-    
-    public var body: some View{
+
+    public var body: some View {
         VStack(alignment: .trailing) {
             if #available(watchOS 9, *), style == .numbers {
                 Stepper(value: number, in: 0...Int.max) {
@@ -127,22 +144,24 @@ public struct EnteredText: View {
                         Text(text)
                             .font(.title2)
                             .minimumScaleFactor(0.5)
+                            .monospacedDigit()
                     }
                     .padding(.horizontal)
                     .frame(height: watchOSDimensions!.height * 0.15, alignment: .trailing)
                 }
                 .focusable()
             } else {
-                Button(action:{
+                Button(action: {
                     presentedAsModal.toggle()
-                }){
+                }) {
                     ZStack(content: {
                         Text("1")
                             .font(.title2)
-                            .foregroundColor(.clear
+                            .foregroundColor(
+                                .clear
                             )
                     })
-                    
+
                     Text(text)
                         .font(.title2)
                         .frame(height: watchOSDimensions!.height * 0.15, alignment: .trailing)
@@ -151,12 +170,12 @@ public struct EnteredText: View {
                 .multilineTextAlignment(.trailing)
                 .lineLimit(1)
             }
-            
+
             DigetPadView(text: $text, style: style, locale: locale)
-                .edgesIgnoringSafeArea(/*@START_MENU_TOKEN@*/.all/*@END_MENU_TOKEN@*/)
+                .edgesIgnoringSafeArea( /*@START_MENU_TOKEN@*/.all /*@END_MENU_TOKEN@*/)
         }
         .toolbar(content: {
-            ToolbarItem(placement: .cancellationAction){
+            ToolbarItem(placement: .cancellationAction) {
                 Button {
                     presentedAsModal.toggle()
                 } label: {
@@ -164,7 +183,7 @@ public struct EnteredText: View {
                 }
             }
         })
-        
+
     }
 }
 
@@ -175,13 +194,13 @@ public struct EnteredText: View {
 @available(tvOS, unavailable)
 public struct DigetPadView: View {
     public var widthSpace: CGFloat = 1.0
-    @Binding var text:String
+    @Binding var text: String
     var style: KeyboardStyle
     private var decimalSeparator: String
     public init(text: Binding<String>, style: KeyboardStyle, locale: Locale = .current) {
         _text = text
         self.style = style
-        
+
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = locale
         decimalSeparator = numberFormatter.decimalSeparator
@@ -206,17 +225,17 @@ public struct DigetPadView: View {
                 .font(.title3.bold())
             } else {
                 VStack(spacing: 1) {
-                    HStack(spacing: widthSpace){
+                    HStack(spacing: widthSpace) {
                         topRow
                     }
-                    HStack(spacing:widthSpace){
+                    HStack(spacing: widthSpace) {
                         upMidRow
                     }
-                    
-                    HStack(spacing:widthSpace){
+
+                    HStack(spacing: widthSpace) {
                         lowMidRow
                     }
-                    HStack(spacing:widthSpace) {
+                    HStack(spacing: widthSpace) {
                         bottomRow
                     }
                 }
@@ -224,7 +243,7 @@ public struct DigetPadView: View {
             }
         }
     }
-    
+
     var topRow: some View {
         Group {
             Button(action: {
@@ -240,7 +259,7 @@ public struct DigetPadView: View {
                 Text("2")
             }
             .digitKeyFrame()
-            
+
             Button(action: {
                 text.append("3")
             }) {
@@ -249,7 +268,7 @@ public struct DigetPadView: View {
             .digitKeyFrame()
         }
     }
-    
+
     var upMidRow: some View {
         Group {
             Button(action: {
@@ -264,7 +283,7 @@ public struct DigetPadView: View {
                 Text("5")
             }
             .digitKeyFrame()
-            
+
             Button(action: {
                 text.append("6")
             }) {
@@ -273,7 +292,7 @@ public struct DigetPadView: View {
             .digitKeyFrame()
         }
     }
-    
+
     var lowMidRow: some View {
         Group {
             Button(action: {
@@ -288,7 +307,7 @@ public struct DigetPadView: View {
                 Text("8")
             }
             .digitKeyFrame()
-            
+
             Button(action: {
                 text.append("9")
             }) {
@@ -297,15 +316,15 @@ public struct DigetPadView: View {
             .digitKeyFrame()
         }
     }
-    
+
     var bottomRow: some View {
         Group {
             if style == .decimal {
                 Button(action: {
-                    if !(text.contains(decimalSeparator)){
-                        if text == ""{
+                    if !(text.contains(decimalSeparator)) {
+                        if text == "" {
                             text.append("0\(decimalSeparator)")
-                        }else{
+                        } else {
                             text.append(decimalSeparator)
                         }
                     }
@@ -323,9 +342,9 @@ public struct DigetPadView: View {
                 Text("0")
             }
             .digitKeyFrame()
-            
+
             Button(action: {
-                if let last = text.indices.last{
+                if let last = text.indices.last {
                     text.remove(at: last)
                 }
             }) {
@@ -341,88 +360,105 @@ struct TextViewStyle: ButtonStyle {
     init(alignment: TextViewAlignment = .center) {
         self.align = alignment
     }
-    
+
     var align: TextViewAlignment
     func makeBody(configuration: Configuration) -> some View {
         HStack {
-            if align == .center || align == .trailing{
+            if align == .center || align == .trailing {
                 Spacer()
             }
             configuration.label
-                .font(/*@START_MENU_TOKEN@*/.body/*@END_MENU_TOKEN@*/)
+                .font( /*@START_MENU_TOKEN@*/.body /*@END_MENU_TOKEN@*/)
                 .padding(.vertical, 11.0)
                 .padding(.horizontal)
-            if align == .center || align == .leading{
+            if align == .center || align == .leading {
                 Spacer()
             }
         }
         .background(
             GeometryReader { geometry in
-                ZStack{
+                ZStack {
                     RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(configuration.isPressed ? Color.gray.opacity(0.1): Color.gray.opacity(0.2))
+                        .fill(
+                            configuration.isPressed
+                                ? Color.gray.opacity(0.1) : Color.gray.opacity(0.2))
                 }
             })
-        
+
     }
-    
+
 }
 
 @available(watchOS 10, *)
 #Preview("Number Only") {
     @Previewable @State var text: String = "0"
-    return DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
+    return DigiTextView(
+        placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
 }
 
 @available(watchOS 10, *)
 #Preview("Number Only") {
     @Previewable @State var number: Int = 0
-    return DigiNumberView(placeholder: "Placeholder", number: $number, presentingModal: false, alignment: .leading)
+    return DigiNumberView(
+        placeholder: "Placeholder", number: $number, presentingModal: false, alignment: .leading)
 }
 
 @available(watchOS 10, *)
 #Preview("Decimals") {
     @Previewable @State var text: String = "0"
-    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading, style: .decimal)
+    DigiTextView(
+        placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading,
+        style: .decimal)
 }
 
 @available(watchOS 10, *)
 #Preview("Decimal XXXL") {
     @Previewable @State var text: String = "0"
-    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading, style: .decimal)
-        .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+    DigiTextView(
+        placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading,
+        style: .decimal
+    )
+    .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
 }
 
 @available(watchOS 10, *)
 #Preview("Decimal XXXL Accessibility Element") {
     @Previewable @State var text: String = "0"
-    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading, style: .decimal)
-        .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
-        .accessibilityElement(children: /*@START_MENU_TOKEN@*/.contain/*@END_MENU_TOKEN@*/)
+    DigiTextView(
+        placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading,
+        style: .decimal
+    )
+    .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+    .accessibilityElement(children: /*@START_MENU_TOKEN@*/ .contain /*@END_MENU_TOKEN@*/)
 }
 
 @available(watchOS 10, *)
 #Preview("Scroll") {
     @Previewable @State var text: String = ""
-    
+
     ScrollView {
-        ForEach(0 ..< 4) { item in
-            DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
+        ForEach(0..<4) { item in
+            DigiTextView(
+                placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading
+            )
         }
-        Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-            /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
+        Button(action: /*@START_MENU_TOKEN@*/ /*@PLACEHOLDER=Action@*/{} /*@END_MENU_TOKEN@*/) {
+            /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button") /*@END_MENU_TOKEN@*/
         }
     }
 }
 
 @available(watchOS 10, *)
 #Preview("Baseline") {
-    ScrollView{
-        ForEach(0 ..< 4){ item in
-            TextField(/*@START_MENU_TOKEN@*/"Placeholder"/*@END_MENU_TOKEN@*/, text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
+    ScrollView {
+        ForEach(0..<4) { item in
+            TextField( /*@START_MENU_TOKEN@*/
+                "Placeholder" /*@END_MENU_TOKEN@*/,
+                text: /*@START_MENU_TOKEN@*/ /*@PLACEHOLDER=Value@*/.constant(
+                    "") /*@END_MENU_TOKEN@*/)
         }
-        Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-            /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
+        Button(action: /*@START_MENU_TOKEN@*/ /*@PLACEHOLDER=Action@*/{} /*@END_MENU_TOKEN@*/) {
+            /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button") /*@END_MENU_TOKEN@*/
         }
     }
 }

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -88,6 +88,7 @@ public struct EnteredText: View {
                     }
                     .padding(.horizontal)
                 }
+                .focusable()
             } else {
                 Button(action:{
                     presentedAsModal.toggle()
@@ -123,6 +124,7 @@ public struct EnteredText: View {
         
     }
 }
+
 @available(watchOS 6.0, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
@@ -251,7 +253,6 @@ struct TextViewStyle: ButtonStyle {
     init(alignment: TextViewAlignment = .center) {
         self.align = alignment
     }
-    
     
     var align: TextViewAlignment
     func makeBody(configuration: Configuration) -> some View {

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -55,7 +55,6 @@ public struct DigiTextView: View {
 @available(tvOS, unavailable)
 public struct DigiNumberView: View {
     private var locale: Locale
-    var style: KeyboardStyle
     var placeholder: String
     @Binding public var number: Int
     @State public var presentingModal: Bool

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -20,7 +20,7 @@ public struct DigiTextView: View {
     @State public var presentingModal: Bool
     
     var align: TextViewAlignment
-    public init( placeholder: String, text: Binding<String>, presentingModal:Bool, alignment: TextViewAlignment = .center,style: KeyboardStyle = .numbers, locale: Locale = .current){
+    public init(placeholder: String, text: Binding<String>, presentingModal:Bool, alignment: TextViewAlignment = .center,style: KeyboardStyle = .numbers, locale: Locale = .current){
         _text = text
         _presentingModal = State(initialValue: presentingModal)
         self.align = alignment
@@ -47,6 +47,49 @@ public struct DigiTextView: View {
             })
     }
 }
+
+@available(watchOS 6.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+public struct DigiNumberView: View {
+    private var locale: Locale
+    var style: KeyboardStyle
+    var placeholder: String
+    @Binding public var number: Int
+    @State public var presentingModal: Bool
+    
+    var align: TextViewAlignment
+    public init(placeholder: String, number: Binding<Int>, presentingModal:Bool, alignment: TextViewAlignment = .center,style: KeyboardStyle = .numbers, locale: Locale = .current){
+        _number = number
+        _presentingModal = State(initialValue: presentingModal)
+        self.align = alignment
+        self.placeholder = placeholder
+        self.style = style
+        self.locale = locale
+    }
+    
+    var text: Binding<String> {
+        Binding {
+            number.description
+        } set: { newValue in
+            number = Int(newValue) ?? 0
+        }
+    }
+    
+    public var body: some View {
+        Button(action: {
+            presentingModal.toggle()
+        }) {
+            Text(number.description)
+        }.buttonStyle(TextViewStyle(alignment: align))
+            .sheet(isPresented: $presentingModal, content: {
+                EnteredText(text: text, presentedAsModal: $presentingModal, style: self.style, locale: locale)
+            })
+    }
+}
+
 @available(watchOS 6.0, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
@@ -79,11 +122,11 @@ public struct EnteredText: View {
     
     public var body: some View{
         VStack(alignment: .trailing) {
-            if #available(watchOS 26, *) {
+            if #available(watchOS 9, *), style == .numbers {
                 Stepper(value: number, in: 0...Int.max) {
                     HStack {
                         Spacer()
-                        Text(number.wrappedValue.description)
+                        Text(text)
                             .font(.body)
                     }
                     .padding(.horizontal)
@@ -281,57 +324,55 @@ struct TextViewStyle: ButtonStyle {
 }
 #endif
 
-//#if DEBUG && os(watchOS)
-//struct EnteredText_Previews: PreviewProvider {
-//    static var previews: some View {
-//        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers)
-//        Group {
-//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
-//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
-//                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
-//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal)
-//                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
-//                .accessibilityElement(children: /*@START_MENU_TOKEN@*/.contain/*@END_MENU_TOKEN@*/)
-//            
-//        }
-//        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 6 - 40mm")
-//        Group {
-//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers).previewDevice("Apple Watch Series 3 - 38mm")
-//            EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .numbers).environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge).previewDevice("Apple Watch Series 3 - 38mm")
-//        }
-//        EnteredText( text: .constant(""), presentedAsModal: .constant(true), style: .decimal).previewDevice("Apple Watch Series 3 - 42mm")
-//    }
-//}
-//
-//struct Content_View_Previews: PreviewProvider {
-//    static var previews: some View{
-//        ScrollView {
-//            ForEach(0 ..< 4) { item in
-//                DigiTextView(placeholder: "Placeholder", text: .constant(""), presentingModal: false, alignment: .leading)
-//            }
-//            Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-//                /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
-//            }
-//        }
-//    }
-//}
-//
-//struct TextField_Previews: PreviewProvider {
-//    static var previews: some View{
-//        ScrollView{
-//            ForEach(0 ..< 4){ item in
-//                TextField(/*@START_MENU_TOKEN@*/"Placeholder"/*@END_MENU_TOKEN@*/, text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
-//            }
-//            Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
-//                /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
-//            }
-//        }
-//    }
-//}
-//#endif
-
 @available(watchOS 10, *)
-#Preview {
+#Preview("Number Only") {
     @Previewable @State var text: String = "0"
     DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
+}
+
+@available(watchOS 10, *)
+#Preview("Decimals") {
+    @Previewable @State var text: String = "0"
+    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading, style: .decimal)
+}
+
+@available(watchOS 10, *)
+#Preview("Decimal XXXL") {
+    @Previewable @State var text: String = "0"
+    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading, style: .decimal)
+        .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+}
+
+@available(watchOS 10, *)
+#Preview("Decimal XXXL Accessibility Element") {
+    @Previewable @State var text: String = "0"
+    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: true, alignment: .leading, style: .decimal)
+        .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+        .accessibilityElement(children: /*@START_MENU_TOKEN@*/.contain/*@END_MENU_TOKEN@*/)
+}
+
+@available(watchOS 10, *)
+#Preview("Scroll") {
+    @Previewable @State var text: String = ""
+    
+    ScrollView {
+        ForEach(0 ..< 4) { item in
+            DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
+        }
+        Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
+            /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
+        }
+    }
+}
+
+@available(watchOS 10, *)
+#Preview("Baseline") {
+    ScrollView{
+        ForEach(0 ..< 4){ item in
+            TextField(/*@START_MENU_TOKEN@*/"Placeholder"/*@END_MENU_TOKEN@*/, text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
+        }
+        Button(action: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Action@*/{}/*@END_MENU_TOKEN@*/) {
+            /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Content@*/Text("Button")/*@END_MENU_TOKEN@*/
+        }
+    }
 }

--- a/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
+++ b/Sources/SwiftUI Apple Watch Decimal Pad/DigetPadView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-#if os(watchOS)
+
 @available(watchOS 6.0, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
@@ -123,11 +123,13 @@ public struct EnteredText: View {
             if #available(watchOS 9, *), style == .numbers {
                 Stepper(value: number, in: 0...Int.max) {
                     HStack {
-                        Spacer()
+                        Spacer(minLength: 0)
                         Text(text)
-                            .font(.body)
+                            .font(.title2)
+                            .minimumScaleFactor(0.5)
                     }
                     .padding(.horizontal)
+                    .frame(height: watchOSDimensions!.height * 0.15, alignment: .trailing)
                 }
                 .focusable()
             } else {
@@ -185,107 +187,152 @@ public struct DigetPadView: View {
         decimalSeparator = numberFormatter.decimalSeparator
     }
     public var body: some View {
-        VStack(spacing: 1) {
-            HStack(spacing: widthSpace){
-                Button(action: {
-                    text.append("1")
-                }) {
-                    Text("1")
-                        .padding(0)
-                }
-                .digitKeyFrame()
-                Button(action: {
-                    text.append("2")
-                }) {
-                    Text("2")
-                }
-                .digitKeyFrame()
-                
-                Button(action: {
-                    text.append("3")
-                }) {
-                    Text("3")
-                }
-                .digitKeyFrame()
-            }
-            HStack(spacing:widthSpace){
-                Button(action: {
-                    text.append("4")
-                }) {
-                    Text("4")
-                }.digitKeyFrame()
-                Button(action: {
-                    text.append("5")
-                }) {
-                    Text("5")
-                }
-                .digitKeyFrame()
-                
-                Button(action: {
-                    text.append("6")
-                }) {
-                    Text("6")
-                }
-                .digitKeyFrame()
-            }
-            
-            HStack(spacing:widthSpace){
-                Button(action: {
-                    text.append("7")
-                }) {
-                    Text("7")
-                }
-                .digitKeyFrame()
-                Button(action: {
-                    text.append("8")
-                }) {
-                    Text("8")
-                }
-                .digitKeyFrame()
-                
-                Button(action: {
-                    text.append("9")
-                }) {
-                    Text("9")
-                }
-                .digitKeyFrame()
-            }
-            HStack(spacing:widthSpace) {
-                if style == .decimal {
-                    Button(action: {
-                        if !(text.contains(decimalSeparator)){
-                            if text == ""{
-                                text.append("0\(decimalSeparator)")
-                            }else{
-                                text.append(decimalSeparator)
-                            }
-                        }
-                    }) {
-                        Text(decimalSeparator)
+        Group {
+            if #available(watchOS 26, *) {
+                Grid(horizontalSpacing: widthSpace, verticalSpacing: 1) {
+                    GridRow {
+                        topRow
                     }
-                    .digitKeyFrame()
-                } else {
-                    Spacer()
-                        .padding(1)
-                }
-                Button(action: {
-                    text.append("0")
-                }) {
-                    Text("0")
-                }
-                .digitKeyFrame()
-                
-                Button(action: {
-                    if let last = text.indices.last{
-                        text.remove(at: last)
+                    GridRow {
+                        upMidRow
                     }
-                }) {
-                    Image(systemName: "delete.left")
+                    GridRow {
+                        lowMidRow
+                    }
+                    GridRow {
+                        bottomRow
+                    }
                 }
-                .digitKeyFrame()
+                .font(.title3.bold())
+            } else {
+                VStack(spacing: 1) {
+                    HStack(spacing: widthSpace){
+                        topRow
+                    }
+                    HStack(spacing:widthSpace){
+                        upMidRow
+                    }
+                    
+                    HStack(spacing:widthSpace){
+                        lowMidRow
+                    }
+                    HStack(spacing:widthSpace) {
+                        bottomRow
+                    }
+                }
+                .font(.title2)
             }
         }
-        .font(.title2)
+    }
+    
+    var topRow: some View {
+        Group {
+            Button(action: {
+                text.append("1")
+            }) {
+                Text("1")
+                    .padding(0)
+            }
+            .digitKeyFrame()
+            Button(action: {
+                text.append("2")
+            }) {
+                Text("2")
+            }
+            .digitKeyFrame()
+            
+            Button(action: {
+                text.append("3")
+            }) {
+                Text("3")
+            }
+            .digitKeyFrame()
+        }
+    }
+    
+    var upMidRow: some View {
+        Group {
+            Button(action: {
+                text.append("4")
+            }) {
+                Text("4")
+            }
+            .digitKeyFrame()
+            Button(action: {
+                text.append("5")
+            }) {
+                Text("5")
+            }
+            .digitKeyFrame()
+            
+            Button(action: {
+                text.append("6")
+            }) {
+                Text("6")
+            }
+            .digitKeyFrame()
+        }
+    }
+    
+    var lowMidRow: some View {
+        Group {
+            Button(action: {
+                text.append("7")
+            }) {
+                Text("7")
+            }
+            .digitKeyFrame()
+            Button(action: {
+                text.append("8")
+            }) {
+                Text("8")
+            }
+            .digitKeyFrame()
+            
+            Button(action: {
+                text.append("9")
+            }) {
+                Text("9")
+            }
+            .digitKeyFrame()
+        }
+    }
+    
+    var bottomRow: some View {
+        Group {
+            if style == .decimal {
+                Button(action: {
+                    if !(text.contains(decimalSeparator)){
+                        if text == ""{
+                            text.append("0\(decimalSeparator)")
+                        }else{
+                            text.append(decimalSeparator)
+                        }
+                    }
+                }) {
+                    Text(decimalSeparator)
+                }
+                .digitKeyFrame()
+            } else {
+                Spacer()
+                    .padding(1)
+            }
+            Button(action: {
+                text.append("0")
+            }) {
+                Text("0")
+            }
+            .digitKeyFrame()
+            
+            Button(action: {
+                if let last = text.indices.last{
+                    text.remove(at: last)
+                }
+            }) {
+                Image(systemName: "delete.left")
+            }
+            .digitKeyFrame()
+        }
     }
 }
 
@@ -320,12 +367,17 @@ struct TextViewStyle: ButtonStyle {
     }
     
 }
-#endif
 
 @available(watchOS 10, *)
 #Preview("Number Only") {
     @Previewable @State var text: String = "0"
-    DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
+    return DigiTextView(placeholder: "Placeholder", text: $text, presentingModal: false, alignment: .leading)
+}
+
+@available(watchOS 10, *)
+#Preview("Number Only") {
+    @Previewable @State var number: Int = 0
+    return DigiNumberView(placeholder: "Placeholder", number: $number, presentingModal: false, alignment: .leading)
 }
 
 @available(watchOS 10, *)


### PR DESCRIPTION
Also in this PR: adding proper SwiftUI `#Previews` with working state vars so that contributors can verify that the UI works functionally and adding an initializer that takes an actual number in, for non decimal use